### PR TITLE
Fix for empty front matter

### DIFF
--- a/src/Document.php
+++ b/src/Document.php
@@ -9,9 +9,9 @@ class Document
     protected $matter;
     protected $body;
 
-    public function __construct(array $matter, string $body)
+    public function __construct($matter = [], string $body)
     {
-        $this->matter = $matter;
+        $this->matter = is_array($matter) ? $matter : [];
         $this->body = $body;
     }
 


### PR DESCRIPTION
This prevents an exception when the front matter is provided but empty.