### PR TITLE
Avoid parsing Markdown Extra tables as YAML

### DIFF
--- a/src/YamlFrontMatter.php
+++ b/src/YamlFrontMatter.php
@@ -8,7 +8,7 @@ class YamlFrontMatter
 {
     public static function parse(string $content): Document
     {
-        $pattern = '/[\s\r\n]---[\s\r\n]/s';
+        $pattern = '/[\r\n]---[\s\r\n]/s';
 
         $parts = preg_split($pattern, PHP_EOL . ltrim($content));
 


### PR DESCRIPTION
If you run [this gist](https://gist.github.com/lsd2prozac/8c7fc0fa2e8ae81b79abeb4db0747caf), you'll get an error because it detects a Markdown extra table as a YAML "zone". This PR fixes that, while keeping the ability to parse normal ZAML "zones".