### PR TITLE
Allow Symfony 5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": ">=7.0",
-        "symfony/yaml": "^3.0|^4.0"
+        "symfony/yaml": "^3.0|^4.0|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5"


### PR DESCRIPTION
This will allow use of `symfony/yaml` with Symfony's 5.x releases.