### PR TITLE
Added namespace use in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ Lorem ipsum.
 ```
 
 ```php
+use Spatie\YamlFrontMatter\YamlFrontMatter;
+
 $object = YamlFrontMatter::parse(file_get_contents(__DIR__.'/example.md'));
 
 $object->matter('title'); // => 'Example';
@@ -50,6 +52,7 @@ $ composer require spatie/yaml-front-matter
 Consider the `example.md` file from above. First you'll need to parse the contents:
 
 ```php
+use Spatie\YamlFrontMatter\YamlFrontMatter;
 $object = YamlFrontMatter::parse(file_get_contents('example.md'));
 ```
 


### PR DESCRIPTION
I've added this to the README as I needed this package a couple times now and always have to go to the file to find the namespace so I thought it would be easier to have it in the README as many do.

```
use Spatie\YamlFrontMatter\YamlFrontMatter;
```

If you accept this please add the `hacktoberfest-accepted` label :) I just wanted to contribute to a repo I like and use.