### PR TITLE
Fix #30, bug where the package cannot properly parse a file that contains Markdown code blocks with front matter in them

### DIFF
--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -49,7 +49,7 @@ class ComplexMarkdownParser
             $this->frontMatterStartLine = $lineNumber;
             return;
         }
-        
+
         if (!isset($this->frontMatterEndLine)) {
             $this->frontMatterEndLine = $lineNumber;
         }
@@ -96,5 +96,4 @@ class ComplexMarkdownParser
     {
         return substr($line, 0, 3) === '---';
     }
-
 }

--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -4,52 +4,21 @@ namespace Spatie\YamlFrontMatter;
 
 use Symfony\Component\Yaml\Yaml;
 
-/**
- * A parser that can handle Markdown that contains Markdown.
- *
- * Attempts to follow the practices defined in https://jekyllrb.com/docs/front-matter/.
- */
 class ComplexMarkdownParser
 {
-    /**
-     * The Markdown content.
-     * @var string
-     */
     protected $content;
-
-    /**
-     * The document string as an array of lines,
-     * making it easier to understand and work with.
-     * @var array
-     */
     protected $lines;
 
-    /**
-     * The line number of the starting front matter control block.
-     * @var int|null
-     */
     public $frontMatterStartLine;
-
-    /**
-     * The line number of the ending front matter control block.
-     * @var int|null
-     */
     public $frontMatterEndLine;
 
-    /**
-     * Construct the parser.
-     * @param string $content The Markdown content to parse.
-     */
     public function __construct(string $content)
     {
         $this->content = $content;
         $this->lines = explode("\n", $this->content);
     }
 
-    /**
-     * Parse the Markdown content.
-     * @return Document
-     */
+   
     public function parse(): Document
     {
         $this->findFrontMatterStartAndEndLineNumbers();
@@ -66,21 +35,11 @@ class ComplexMarkdownParser
         return new Document($matter, $body);
     }
 
-    /**
-     * Is a given line a front matter control block?
-     *
-     * A control block is a line that starts with three dashes.
-     * @param string $line
-     * @return bool
-     */
     private function isFrontMatterControlBlock(string $line): bool
     {
         return substr($line, 0, 3) === '---';
     }
 
-    /**
-     * Find and set the line numbers of the front matter start and end blocks.
-     */
     private function findFrontMatterStartAndEndLineNumbers()
     {
         foreach ($this->lines as $lineNumber => $lineContents) {
@@ -90,12 +49,6 @@ class ComplexMarkdownParser
         }
     }
 
-    /**
-     * Set the appropriate line number for the front matter start or end block.
-     *
-     * @param $lineNumber int the current line number of the search.
-     * @return void
-     */
     private function setFrontMatterLineNumber(int $lineNumber)
     {
         if (!isset($this->frontMatterStartLine)) {
@@ -107,22 +60,12 @@ class ComplexMarkdownParser
         }
     }
 
-    /**
-     * Does the current document have front matter?
-     * @return bool
-     */
     private function hasFrontMatter(): bool
     {
         return ($this->frontMatterStartLine !== null) && ($this->frontMatterEndLine !== null);
     }
 
-    /**
-     * Get the front matter from the document.
-     *
-     * Works by collecting all the lines before the end block,
-     * while skipping over the actual control blocks.
-     * @return string
-     */
+   
     private function getFrontMatter(): string
     {
         $matter = [];
@@ -136,12 +79,6 @@ class ComplexMarkdownParser
         return implode("\n", $matter);
     }
 
-    /**
-     * Get the body of the document.
-     *
-     * Works by collecting all the lines after the end block.
-     * @return string
-     */
     private function getBody(): string
     {
         $body = [];
@@ -153,11 +90,6 @@ class ComplexMarkdownParser
         return implode("\n", $this->trimBody($body));
     }
 
-    /**
-     * If the first line of the body is empty, remove it.
-     * @param array $body
-     * @return array
-     */
     private function trimBody(array $body): array
     {
         if (trim($body[0]) === '') {

--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Spatie\YamlFrontMatter;
+
+use Symfony\Component\Yaml\Yaml;
+
+/**
+ * A parser that can handle Markdown that contains Markdown.
+ *
+ * Attempts to follow the practices defined in https://jekyllrb.com/docs/front-matter/.
+ *
+ * Fixes https://github.com/spatie/yaml-front-matter/discussions/30.
+ *
+ * @param string $content
+ * @return Document
+ */
+class ComplexMarkdownParser
+{
+    /**
+     * The Markdown content
+     * @var string
+     */
+    protected $content;
+
+    /**
+     * The document string as an array of lines
+     * @var array
+     */
+    protected $lines;
+
+    /**
+     * The line number of the starting front matter control block
+     * @var int|null
+     */
+    public $frontMatterStartLine;
+
+    /**
+     * The line number of the ending front matter control block
+     * @var int|null
+     */
+    public $frontMatterEndLine;
+
+    public function __construct(string $content)
+    {
+        $this->content = $content;
+        // Turn the string into an array of lines, making the code easier to understand
+        $this->lines = explode("\n", $this->content);
+    }
+
+    /**
+     * A parser that can handle Markdown that contains Markdown.
+     * @return Document
+     */
+    public function parse(): Document
+    {
+        // Find the line numbers of the front matter start and end blocks
+        $this->findFrontMatterStartAndEndLineNumbers();
+
+        // If there are no front matter blocks, we just return the content as is
+        if (!$this->hasFrontMatter()) {
+            return new Document([], $this->content);
+        }
+
+        // Construct the new line arrays
+        $matter = [];
+        $body = [];
+
+        // Loop through the original line array
+        foreach ($this->lines as $lineNumber => $lineContents) {
+            // Compare the line number to the one of the closing front matter block
+            // to determine if we're in the front matter or the body
+            if ($lineNumber <= $this->frontMatterEndLine) {
+                $matter[] = $lineContents;
+            } else {
+                $body[] = $lineContents;
+            }
+        }
+
+        // Remove the dashes
+        unset($matter[$this->frontMatterStartLine]);
+        unset($matter[$this->frontMatterEndLine]);
+
+        // If the first line of the body is empty, remove it
+        if (trim($body[0]) === '') {
+            unset($body[0]);
+        }
+
+        // Convert the lines back into strings
+        $matter = implode("\n", $matter);
+        $body = implode("\n", $body);
+
+        // Parse the front matter
+        $matter = Yaml::parse($matter);
+
+        // Return the document
+        return new Document($matter, $body);
+    }
+
+    /**
+     * Is a given line a front matter control block?
+     *
+     * A control block is a line that starts with three dashes.
+     *
+     * @param string $line
+     * @return bool
+     */
+    private function isFrontMatterControlBlock(string $line): bool
+    {
+        return substr($line, 0, 3) === '---';
+    }
+
+    /**
+     * Does the current document have front matter?
+     * @return bool
+     */
+    private function hasFrontMatter(): bool
+    {
+        return $this->frontMatterStartLine !== null && $this->frontMatterEndLine !== null;
+    }
+
+    private function findFrontMatterStartAndEndLineNumbers()
+    {
+        foreach ($this->lines as $lineNumber => $lineContents) {
+            // If the line starts with three dashes, it's a front matter control block
+            if ($this->isFrontMatterControlBlock($lineContents)) {
+                // The line contains the front matter control block
+                if (!isset($this->frontMatterStartLine)) {
+                    // This is the first control block
+                    $this->frontMatterStartLine = $lineNumber;
+                } elseif (!isset($this->frontMatterEndLine)) {
+                    // This is the second control block
+                    $this->frontMatterEndLine = $lineNumber;
+                    // We can now break the loop because we found the end of the actual front matter
+                    break;
+                }
+            }
+        }
+    }
+}

--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -34,11 +34,6 @@ class ComplexMarkdownParser
         return new Document($matter, $body);
     }
 
-    protected function isFrontMatterControlBlock(string $line): bool
-    {
-        return substr($line, 0, 3) === '---';
-    }
-
     protected function findFrontMatterStartAndEndLineNumbers()
     {
         foreach ($this->lines as $lineNumber => $lineContents) {
@@ -54,16 +49,11 @@ class ComplexMarkdownParser
             $this->frontMatterStartLine = $lineNumber;
             return;
         }
+        
         if (!isset($this->frontMatterEndLine)) {
             $this->frontMatterEndLine = $lineNumber;
         }
     }
-
-    protected function hasFrontMatter(): bool
-    {
-        return ($this->frontMatterStartLine !== null) && ($this->frontMatterEndLine !== null);
-    }
-
 
     protected function getFrontMatter(): string
     {
@@ -96,4 +86,15 @@ class ComplexMarkdownParser
         }
         return $body;
     }
+
+    protected function hasFrontMatter(): bool
+    {
+        return ($this->frontMatterStartLine !== null) && ($this->frontMatterEndLine !== null);
+    }
+
+    protected function isFrontMatterControlBlock(string $line): bool
+    {
+        return substr($line, 0, 3) === '---';
+    }
+
 }

--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -18,7 +18,6 @@ class ComplexMarkdownParser
         $this->lines = explode("\n", $this->content);
     }
 
-   
     public function parse(): Document
     {
         $this->findFrontMatterStartAndEndLineNumbers();
@@ -35,12 +34,12 @@ class ComplexMarkdownParser
         return new Document($matter, $body);
     }
 
-    private function isFrontMatterControlBlock(string $line): bool
+    protected function isFrontMatterControlBlock(string $line): bool
     {
         return substr($line, 0, 3) === '---';
     }
 
-    private function findFrontMatterStartAndEndLineNumbers()
+    protected function findFrontMatterStartAndEndLineNumbers()
     {
         foreach ($this->lines as $lineNumber => $lineContents) {
             if ($this->isFrontMatterControlBlock($lineContents)) {
@@ -49,7 +48,7 @@ class ComplexMarkdownParser
         }
     }
 
-    private function setFrontMatterLineNumber(int $lineNumber)
+    protected function setFrontMatterLineNumber(int $lineNumber)
     {
         if (!isset($this->frontMatterStartLine)) {
             $this->frontMatterStartLine = $lineNumber;
@@ -60,13 +59,13 @@ class ComplexMarkdownParser
         }
     }
 
-    private function hasFrontMatter(): bool
+    protected function hasFrontMatter(): bool
     {
         return ($this->frontMatterStartLine !== null) && ($this->frontMatterEndLine !== null);
     }
 
-   
-    private function getFrontMatter(): string
+
+    protected function getFrontMatter(): string
     {
         $matter = [];
         foreach ($this->lines as $lineNumber => $lineContents) {
@@ -79,7 +78,7 @@ class ComplexMarkdownParser
         return implode("\n", $matter);
     }
 
-    private function getBody(): string
+    protected function getBody(): string
     {
         $body = [];
         foreach ($this->lines as $lineNumber => $lineContents) {
@@ -90,7 +89,7 @@ class ComplexMarkdownParser
         return implode("\n", $this->trimBody($body));
     }
 
-    private function trimBody(array $body): array
+    protected function trimBody(array $body): array
     {
         if (trim($body[0]) === '') {
             unset($body[0]);

--- a/src/ComplexMarkdownParser.php
+++ b/src/ComplexMarkdownParser.php
@@ -8,16 +8,11 @@ use Symfony\Component\Yaml\Yaml;
  * A parser that can handle Markdown that contains Markdown.
  *
  * Attempts to follow the practices defined in https://jekyllrb.com/docs/front-matter/.
- *
- * Fixes https://github.com/spatie/yaml-front-matter/discussions/30.
- *
- * @param string $content
- * @return Document
  */
 class ComplexMarkdownParser
 {
     /**
-     * The Markdown content
+     * The Markdown content.
      * @var string
      */
     protected $content;
@@ -30,17 +25,21 @@ class ComplexMarkdownParser
     protected $lines;
 
     /**
-     * The line number of the starting front matter control block
+     * The line number of the starting front matter control block.
      * @var int|null
      */
     public $frontMatterStartLine;
 
     /**
-     * The line number of the ending front matter control block
+     * The line number of the ending front matter control block.
      * @var int|null
      */
     public $frontMatterEndLine;
 
+    /**
+     * Construct the parser.
+     * @param string $content The Markdown content to parse.
+     */
     public function __construct(string $content)
     {
         $this->content = $content;
@@ -48,7 +47,7 @@ class ComplexMarkdownParser
     }
 
     /**
-     * A parser that can handle Markdown that contains Markdown.
+     * Parse the Markdown content.
      * @return Document
      */
     public function parse(): Document
@@ -79,9 +78,8 @@ class ComplexMarkdownParser
         return substr($line, 0, 3) === '---';
     }
 
-
     /**
-     * Find the line numbers of the front matter start and end blocks.
+     * Find and set the line numbers of the front matter start and end blocks.
      */
     private function findFrontMatterStartAndEndLineNumbers()
     {
@@ -93,13 +91,12 @@ class ComplexMarkdownParser
     }
 
     /**
-     * Find and set the line numbers of the front matter start and end blocks.
+     * Set the appropriate line number for the front matter start or end block.
      *
-     * Ignores any additional front matter blocks found later in the document.
-     * @param $lineNumber
+     * @param $lineNumber int the current line number of the search.
      * @return void
      */
-    private function setFrontMatterLineNumber($lineNumber)
+    private function setFrontMatterLineNumber(int $lineNumber)
     {
         if (!isset($this->frontMatterStartLine)) {
             $this->frontMatterStartLine = $lineNumber;
@@ -116,7 +113,7 @@ class ComplexMarkdownParser
      */
     private function hasFrontMatter(): bool
     {
-        return $this->frontMatterStartLine !== null && $this->frontMatterEndLine !== null;
+        return ($this->frontMatterStartLine !== null) && ($this->frontMatterEndLine !== null);
     }
 
     /**
@@ -157,7 +154,7 @@ class ComplexMarkdownParser
     }
 
     /**
-     * If the first line of the body is empty, remove it
+     * If the first line of the body is empty, remove it.
      * @param array $body
      * @return array
      */

--- a/src/YamlFrontMatter.php
+++ b/src/YamlFrontMatter.php
@@ -25,13 +25,6 @@ class YamlFrontMatter
 
     /**
      * A parser that can handle Markdown that contains Markdown.
-     *
-     * Attempts to follow the practices defined in https://jekyllrb.com/docs/front-matter/.
-     *
-     * Fixes https://github.com/spatie/yaml-front-matter/discussions/30.
-     *
-     * @param string $content
-     * @return Document
      */
     public static function markdownCompatibleParse(string $content): Document
     {

--- a/src/YamlFrontMatter.php
+++ b/src/YamlFrontMatter.php
@@ -23,6 +23,45 @@ class YamlFrontMatter
         return new Document($matter, $body);
     }
 
+    /**
+     * A parser that can handle Markdown that contains Markdown.
+     *
+     * Fixes https://github.com/spatie/yaml-front-matter/discussions/30.
+     * Original code by https://github.com/eklausme
+     *
+     * @param string $content
+     * @return Document
+     */
+    public static function markdownCompatibleParse(string $content): Document
+    {
+        $n3dash = 0;    // count number of triple dashes
+        $pos1 = 0;
+        $pos2 = 0;
+        $len = strlen($content);
+
+        for ($pos = 0; ; $pos += 3) {
+            $pos = strpos($content, '---', $pos);
+            if ($pos === false) return new Document([], $content);   // no pair of triple dashes at all
+            // Are we at end or is next character white space?
+            if ($pos + 3 == $len || ctype_space(substr($content, $pos + 3, 1))) {
+                if ($n3dash == 0 && ($pos == 0 || $pos > 0 && substr($content, $pos - 1, 1) == "\n")) {
+                    $n3dash = 1;    // found first triple dash
+                    $pos1 = $pos + 3;
+                } else if ($n3dash == 1 && substr($content, $pos - 1, 1) == "\n") {
+                    // found 2nd properly enclosed triple dash
+                    $n3dash = 2;
+                    $pos2 = $pos + 3;
+                    break;
+                }
+            }
+        }
+        $matter = substr($content, $pos1, $pos2 - 3 - $pos1);
+        $body = substr($content, $pos2);
+        $matter = Yaml::parse($matter);
+
+        return new Document($matter, $body);
+    }
+
     public static function parseFile(string $path): Document
     {
         return static::parse(

--- a/src/YamlFrontMatter.php
+++ b/src/YamlFrontMatter.php
@@ -35,65 +35,7 @@ class YamlFrontMatter
      */
     public static function markdownCompatibleParse(string $content): Document
     {
-        // Turn the string into an array of lines, making the code easier to understand
-        $lines = explode("\n", $content);
-
-        // Find the line numbers of the front matter start and end blocks
-        $frontMatterControlBlockIndex = [];
-        foreach ($lines as $lineNumber => $lineContents) {
-            // If the line starts with three dashes, it's a front matter control block
-            if (substr($lineContents, 0, 3) === '---') {
-                // The line contains the front matter control block
-                if (sizeof($frontMatterControlBlockIndex) === 0) {
-                    // This is the first control block
-                    $frontMatterControlBlockIndex['start'] = $lineNumber;
-                } elseif (sizeof($frontMatterControlBlockIndex) === 1) {
-                    // This is the second control block
-                    $frontMatterControlBlockIndex['end'] = $lineNumber;
-                    // We can now break the loop because we found the end of the actual front matter
-                    break;
-                }
-            }
-        }
-
-        // If there are no front matter blocks, we just return the content as is
-        if (sizeof($frontMatterControlBlockIndex) < 2) {
-            return new Document([], $content);
-        }
-
-        // Construct the new line arrays
-        $matter = [];
-        $body = [];
-
-        // Loop through the original line array
-        foreach ($lines as $lineNumber => $lineContents) {
-            // Compare the line number to the one of the closing front matter block
-            // to determine if we're in the front matter or the body
-            if ($lineNumber <= $frontMatterControlBlockIndex['end']) {
-                $matter[] = $lineContents;
-            } else {
-                $body[] = $lineContents;
-            }
-        }
-
-        // Remove the dashes
-        unset($matter[$frontMatterControlBlockIndex['start']]);
-        unset($matter[$frontMatterControlBlockIndex['end']]);
-
-        // If the first line of the body is empty, remove it
-        if (trim($body[0]) === '') {
-            unset($body[0]);
-        }
-
-        // Convert the lines back into strings
-        $matter = implode("\n", $matter);
-        $body = implode("\n", $body);
-        
-        // Parse the front matter
-        $matter = Yaml::parse($matter);
-
-        // Return the document
-        return new Document($matter, $body);
+        return (new ComplexMarkdownParser($content))->parse();
     }
 
     public static function parseFile(string $path): Document

--- a/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
+++ b/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Spatie\YamlFrontMatter\Tests;
+
+use Spatie\YamlFrontMatter\Document;
+use Spatie\YamlFrontMatter\YamlFrontMatter;
+use PHPUnit\Framework\TestCase;
+
+class YamlFrontMatterMarkdownCompatibleParseTest extends TestCase
+{
+    /** @test */
+    public function it_can_parse_simple_front_matter_from_a_file()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+            file_get_contents(__DIR__.'/document.md')
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEquals(['foo' => 'bar'], $document->matter());
+        $this->assertStringContainsString('Lorem ipsum.', $document->body());
+    }
+
+    /** @test */
+    public function it_can_parse_complex_front_matter_from_a_file()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+            file_get_contents(__DIR__.'/meta-document.md')
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEquals(['foo' => 'bar'], $document->matter());
+        $this->assertStringContainsString('Lorem ipsum.', $document->body());
+    }
+}

--- a/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
+++ b/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
@@ -31,7 +31,7 @@ class YamlFrontMatterMarkdownCompatibleParseTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $document->matter());
         $this->assertStringContainsString('Lorem ipsum.', $document->body());
     }
-    
+
     /** @test */
     public function it_separates_the_front_matter_from_the_body()
     {
@@ -46,13 +46,13 @@ class YamlFrontMatterMarkdownCompatibleParseTest extends TestCase
         // This implicitly asserts that the body does not contain any front matter remnants
         $this->assertEquals('Lorem ipsum.', $document->body());
     }
-       
+
     /** @test */
     public function it_leaves_string_without_front_matter_intact()
     {
         $document = YamlFrontMatter::markdownCompatibleParse(
             "Lorem ipsum."
-        ); 
+        );
 
         $this->assertInstanceOf(Document::class, $document);
         $this->assertEmpty($document->matter());
@@ -72,5 +72,29 @@ class YamlFrontMatterMarkdownCompatibleParseTest extends TestCase
         $this->assertInstanceOf(Document::class, $document);
         $this->assertEmpty($document->matter());
         $this->assertEquals("---\ntitle: Front Matter\n\nLorem ipsum.", $document->body());
+    }
+
+    /** @test */
+    public function it_can_parse_a_string_with_unix_line_endings()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+           "---\nfoo: bar\n---\n\nLorem ipsum."
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEquals(['foo' => 'bar'], $document->matter());
+        $this->assertStringContainsString('Lorem ipsum.', $document->body());
+    }
+
+    /** @test */
+    public function it_can_parse_a_string_with_windows_line_endings()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+           "---\r\nfoo: bar\r\n---\r\n\r\nLorem ipsum."
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEquals(['foo' => 'bar'], $document->matter());
+        $this->assertStringContainsString('Lorem ipsum.', $document->body());
     }
 }

--- a/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
+++ b/tests/YamlFrontMatterMarkdownCompatibleParseTest.php
@@ -31,4 +31,46 @@ class YamlFrontMatterMarkdownCompatibleParseTest extends TestCase
         $this->assertEquals(['foo' => 'bar'], $document->matter());
         $this->assertStringContainsString('Lorem ipsum.', $document->body());
     }
+    
+    /** @test */
+    public function it_separates_the_front_matter_from_the_body()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+           "---\ntitle: Front Matter\n---\n\nLorem ipsum."
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+
+        // This implicitly asserts that the front matter does not contain any markdown
+        $this->assertEquals(['title' => 'Front Matter'], $document->matter());
+        // This implicitly asserts that the body does not contain any front matter remnants
+        $this->assertEquals('Lorem ipsum.', $document->body());
+    }
+       
+    /** @test */
+    public function it_leaves_string_without_front_matter_intact()
+    {
+        $document = YamlFrontMatter::markdownCompatibleParse(
+            "Lorem ipsum."
+        ); 
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEmpty($document->matter());
+        $this->assertEquals('Lorem ipsum.', $document->body());
+    }
+
+    /** @test */
+    public function it_can_parse_a_file_partial_front_matter()
+    {
+        // If there is only one YAML control block, (---) the front matter is invalid
+        // and the document should be interpreted as having no front matter.
+
+        $document = YamlFrontMatter::markdownCompatibleParse(
+           "---\ntitle: Front Matter\n\nLorem ipsum."
+        );
+
+        $this->assertInstanceOf(Document::class, $document);
+        $this->assertEmpty($document->matter());
+        $this->assertEquals("---\ntitle: Front Matter\n\nLorem ipsum.", $document->body());
+    }
 }

--- a/tests/meta-document.md
+++ b/tests/meta-document.md
@@ -1,0 +1,17 @@
+---
+foo: bar
+---
+
+Lorem ipsum.
+
+A paragraph in a Markdown Post.
+This file contains a Markdown code block that the original parser does not handle.
+See https://github.com/spatie/yaml-front-matter/discussions/30.
+
+```
+---
+title: The Title of Markdown Code
+---
+
+A paragraph in Markdown Code
+```


### PR DESCRIPTION
This PR fixes #30 

The PR is fully backwards compatible as it does not change the existing parser, but instead adds a new one: `YamlFrontMatter::markdownCompatibleParse()` which uses code by https://github.com/eklausme (I hope this is okay, I'm happy to add you as a co-author if you see this!

Before:
![image](https://user-images.githubusercontent.com/95144705/160793264-15d59ea1-44a1-4019-9b01-90e41b06aa75.png)

After:
![image](https://user-images.githubusercontent.com/95144705/160793131-0905fb1a-b67b-4e25-b790-b6f7086c70fb.png)

The source markdown used for the example: (with the inline backticks replaced)
```markdown
---
title: test
foo: bar
---

A paragraph in a Markdown Post.
This file contains a Markdown code block that the original parser does not handle.
See https://github.com/spatie/yaml-front-matter/discussions/30.

'''
---
title: The Title of Markdown Code
---

A paragraph in Markdown Code
'''

```