### PR TITLE
PHP 8.4 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.2, 8.1, 8.0, 7.4, 7.3]
+                php: [8.2, 8.1, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
@@ -24,7 +24,7 @@ jobs:
                     php-version: ${{ matrix.php }}
                     extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
                     coverage: none
-                    
+
             -   name: Install dependencies
                 run:  composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -9,7 +9,7 @@ jobs:
             fail-fast: false
             matrix:
                 os: [ubuntu-latest, windows-latest]
-                php: [8.2, 8.1, 8.0]
+                php: [8.4, 8.3, 8.2, 8.1, 8.0]
                 dependency-version: [prefer-lowest, prefer-stable]
 
         name: P${{ matrix.php }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -18,8 +18,8 @@
         }
     ],
     "require": {
-        "php": "^7.0|^8.0",
-        "symfony/yaml": "^3.0|^4.0|^5.0|^6.0|^7.0"
+        "php": "^8.4",
+        "symfony/yaml": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         }
     ],
     "require": {
-        "php": "^8.4",
+        "php": "^8.0",
         "symfony/yaml": "^7.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "symfony/yaml": "^7.0"
+        "symfony/yaml": "^6.0|^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.0"

--- a/src/Document.php
+++ b/src/Document.php
@@ -13,7 +13,7 @@ class Document
         $this->body = $body;
     }
 
-    public function matter(string $key = null, $default = null)
+    public function matter(?string $key = null, mixed $default = null)
     {
         if ($key) {
             return Arr::get($this->matter, $key, $default);


### PR DESCRIPTION
Hi Spatie folks!

So, PHP 8.4 is a tricky one: it deprecates implicit nullable types, which means you'd need to add explicit types. We'd need `mixed`, to solve this issue, meaning the minimum version should be 8.0. I hope you're ok with that minimum version bump.